### PR TITLE
Update runtime to GNOME 48

### DIFF
--- a/io.github.nate_xyz.Chromatic.json
+++ b/io.github.nate_xyz.Chromatic.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.github.nate_xyz.Chromatic",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "45",
+    "runtime-version" : "47",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
Probably not gonna work, considering v47 failed, but might as well try