### PR TITLE
update to gnome 48 runtime

### DIFF
--- a/io.github.nate_xyz.Chromatic.json
+++ b/io.github.nate_xyz.Chromatic.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.github.nate_xyz.Chromatic",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "45",
+    "runtime-version" : "48",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"
@@ -60,7 +60,7 @@
                 {
                     "type" : "git",
                     "url" : "https://github.com/nate-xyz/chromatic",
-                    "commit":"fe9d34e3cb30a045b95aa76f8cc4e3193903e262"
+                    "commit":"ffaeb50dcce74bf3ba1b05f98423cf48f205f55e"
                 }
             ]
         }

--- a/io.github.nate_xyz.Chromatic.json
+++ b/io.github.nate_xyz.Chromatic.json
@@ -60,7 +60,7 @@
                 {
                     "type" : "git",
                     "url" : "https://github.com/nate-xyz/chromatic",
-                    "commit":"ffaeb50dcce74bf3ba1b05f98423cf48f205f55e"
+                    "commit":"fe9d34e3cb30a045b95aa76f8cc4e3193903e262"
                 }
             ]
         }


### PR DESCRIPTION
the runtime is EOL

tested with

`flatpak run --runtime-version=48 io.github.nate_xyz.Chromatic`